### PR TITLE
Optimizations

### DIFF
--- a/back.js
+++ b/back.js
@@ -4,10 +4,10 @@ const fetchLinks = () => {
     fetch("https://woopy.alexiis.fr/websites.json").then(res => {
         res.json().then(j => {
             cache = j;
-            console.log("Links are been fetched !")
+            console.log("Links have been fetched and set to cache.");
         })
     }).catch(err => {
-        console.log("Une erreur est survenue.", err);
+        console.error("An error occured:", err);
     })
 }
 

--- a/back.js
+++ b/back.js
@@ -47,41 +47,7 @@ chrome.tabs.onUpdated.addListener(function(activeInfo) { //When tab is updated
         if(!tabs[0]) return;
         const {url} = tabs[0];
 
-        if(url.startsWith("https://www.")) { //If starts by https://www.
-            var domain = url.substring(12); //Remove 12 characters
-            var cleared = domain.split('/')[0];
-
-            if(checkurl(cleared)) {
-                chrome.tabs.update(tabId ,{url:getURL(domain, cleared)});
-            }
-        } if(url.startsWith("https://")) { //Same
-            var domain = url.substring(8); 
-            var cleared = domain.split('/')[0];
-
-            if(checkurl(cleared)) {
-                chrome.tabs.update(tabId ,{url:getURL(domain, cleared)});
-            }
-        } else if(url.startsWith("http://www.")) { 
-            var domain = url.substring(11); 
-            var cleared = domain.split('/')[0];
-
-            if(checkurl(cleared)) {
-                chrome.tabs.update(tabId ,{url:getURL(domain, cleared)});
-            }
-        } else if(url.startsWith("http://")) { 
-            var domain = url.substring(7); 
-            var cleared = domain.split('/')[0];
-
-            if(checkurl(cleared)) {
-                chrome.tabs.update(tabId ,{url:getURL(domain, cleared)});
-            }
-        }  else if(url.startsWith("www.")) { 
-            var domain = url.substring(4); 
-            var cleared = domain.split('/')[0];
-
-            if(checkurl(cleared)) {
-                chrome.tabs.update(tabId ,{url:getURL(domain, cleared)});
-            }
-        } 
+        let domain = url.replace(/^(?:https?:\/\/)?(?:www\.)?/i, "");
+        let path = domain.split("/")[0];chrome.tabs.update(tabId, {url: getURL(domain, path)});
     });
 });

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Woopy",
   "description": "Allow to accessing to your favorites websites more faster.",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "manifest_version": 3,
   "background": {
     "service_worker": "back.js"

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Woopy",
   "description": "Allow to accessing to your favorites websites more faster.",
-  "version": "3.0.4",
+  "version": "3.0.3",
   "manifest_version": 3,
   "background": {
     "service_worker": "back.js"


### PR DESCRIPTION
Instead of checking every single possibility, we are now getting the domain using the following regex: `/^(?:https?:\/\/)?(?:www\.)?/i`. This reduces the size of the extension (34 lines were removed in total).
Also, I corrected some things in the logs.

And, to conclude, for the changes to be updated as fast as possible on chrome store, I already updated the version and made tests, which passed with success.